### PR TITLE
Add upper bound for scikit-learn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ pandas = [
   {version = "<=1.4.3", python = ">=3.8"}
 ]
 numpy = "<1.24.0"
-scikit-learn = ">=0.22"
+scikit-learn = ">=0.22, <=0.24.2"
 lightgbm = ">=2.3, <=3.2.1"
 catboost = ">=0.26.1"
 optuna = "*"


### PR DESCRIPTION
add upper bound for scikit-learn version (<1.0) to avoid the problem with renamed parameters: "The 'criterion' parameter of RandomForestRegressor must be a str among {'squared_error', 'poisson', 'friedman_mse', 'absolute_error'}. Got 'mse' instead."