### PR TITLE
[BUG] [Poetry env use] Changed ";" to ","

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,12 +87,12 @@ cffi = {version = "1.14.5", optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "6.2.5"
-sphinx = {version = "5.3.0", extras = ["autdoc", "autosummary", "intersphinx", "napoleon", "viewcode"], python = ">=3.8; <3.10"}
-sphinx-autodoc-typehints = {version = "1.19.5", python = ">=3.8; <3.10"}
-sphinx-rtd-theme = {version = "1.1.1", python = ">=3.8; <3.10"}
-nbsphinx = {version = "0.8.10", python = ">=3.8; <3.10"}
-nbsphinx-link = {version = "1.3.0", python = ">=3.8; <3.10"}
-traitlets = {version = ">=5", python = ">=3.8; <3.10"}
+sphinx = {version = "5.3.0", extras = ["autdoc", "autosummary", "intersphinx", "napoleon", "viewcode"], python = ">=3.8, <3.10"}
+sphinx-autodoc-typehints = {version = "1.19.5", python = ">=3.8, <3.10"}
+sphinx-rtd-theme = {version = "1.1.1", python = ">=3.8, <3.10"}
+nbsphinx = {version = "0.8.10", python = ">=3.8, <3.10"}
+nbsphinx-link = {version = "1.3.0", python = ">=3.8, <3.10"}
+traitlets = {version = ">=5", python = ">=3.8, <3.10"}
 ipython = [
     {version = "<7.0.0", python = "<3.8"},
     {version = "8.5.0", python = ">=3.8"}


### PR DESCRIPTION
Fixed `poetry env use PYTHON_PATH`

<img width="962" alt="Error" src="https://user-images.githubusercontent.com/31068060/218091035-5b731980-6678-4b3e-b92b-989903e03a2f.png">

Versions should be listed with , and not with ; 

Changed