### PR TITLE
Update optuna.py exception format to be compatible with Optuna 2.10.1

### DIFF
--- a/lightautoml/ml_algo/tuning/optuna.py
+++ b/lightautoml/ml_algo/tuning/optuna.py
@@ -213,7 +213,7 @@ class OptunaTuner(ParamsTuner):
                     if get_stdout_level() in [logging.INFO, logging.INFO2]
                     else [update_trial_time, check_fail_tolerance]
                 ),
-                catch=[Exception],
+                catch=(Exception,),
             )
 
             # Close the progress bar if it was initialized


### PR DESCRIPTION
LightAutoML: 0.4.1
Optuna: 2.10.1
Error: tuner throws [Exception], whereas optuna expects (Exception,)
Fix: see commit diff