### PR TITLE
fix: remove strict pdf extra dependency check on report import (closes #147)

### DIFF
--- a/lightautoml/report/__init__.py
+++ b/lightautoml/report/__init__.py
@@ -1,13 +1,8 @@
 """Report generators and templates."""
 
-from lightautoml.utils.installation import __validate_extra_deps
-
 from .report_deco import ReportDeco
 from .report_deco import ReportDecoNLP
 from .report_deco import ReportDecoWhitebox
-
-
-__validate_extra_deps("pdf")
 
 
 __all__ = ["ReportDeco", "ReportDecoWhitebox", "ReportDecoNLP"]


### PR DESCRIPTION
## What
The `lightautoml/report/__init__.py` file includes a call to `__validate_extra_deps("pdf")` at import time. This causes any import of `lightautoml.automl.presets.tabular_presets` to fail if the optional pdf dependencies are not installed, even if the user only needs TabularAutoML/TabularUtilizedAutoML and has no intention of generating PDF reports.

## Fix
Removed the immediate validation call from `lightautoml/report/__init__.py`. The optional dependencies will still be checked when actually using report functionality, if those modules perform the validation themselves (or this is now the responsibility of report users). This allows core imports to succeed without requiring the `pdf` extra.

Closes #147