### PR TITLE
fix: bound the generated Python range so poetry can resolve dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.8,<4.0"
 
 poetry-core = "^1.0.0"
 pandas = "*"
@@ -91,7 +91,7 @@ weasyprint = {version = "52.5", optional = true}
 cffi = {version = "1.14.5", optional = true}
 
 # HypEx
-hypex = {version = "*", optional = true}
+hypex = {version = "*", optional = true, python = "<3.14"}
 
 
 [tool.poetry.extras]

--- a/scripts/poetry_fix.py
+++ b/scripts/poetry_fix.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 
 PYPROJECT_TOML = Path("pyproject.toml")
-ALL_PYTHON_DEPS = ">=3.8"
+ALL_PYTHON_DEPS = ">=3.8,<4.0"
 PYTHON_DEPS = {8: "~3.8.0", 9: "~3.9.0", 10: "~3.10.0", 11: "~3.11.0", 12: "~3.12.0"}
 PYTHON_DEPS_PATTERN = '^python = ".*"$'
 


### PR DESCRIPTION
Closes #180

`poetry lock` and `poetry install` fail on a clean checkout of master. This makes the declared Python range match what the dependencies actually allow, without changing which Python versions are supported.

### What is wrong

`scripts/poetry_fix.py` generates the `python` constraint in `pyproject.toml`, and its "all versions" value has no upper bound:

```python
ALL_PYTHON_DEPS = ">=3.8"
```

With no upper bound, Poetry has to find a solution that also holds for Python 3.14, 3.15 and beyond, up to and including 4.x. Nothing satisfies that. The solver reports `hypex` first (no release goes above `<3.14`), and once that is excluded it fails on `featuretools`, which requires `<4` — as do most packages on PyPI.

Because the constraint is generated, editing line 34 by hand does not help: the `set-py-versions` pre-commit hook rewrites it back on the next run. The fix has to go into the constant.

### What this changes

- `ALL_PYTHON_DEPS` becomes `">=3.8,<4.0"`, and `pyproject.toml` picks that up through the hook.
- `hypex` gets `python = "<3.14"`, since no published release supports 3.14.

No supported Python version is dropped. `<4.0` only excludes Python 4, which does not exist — and which the package could not have been installed on anyway, since the required `featuretools` already caps at `<4`. The marker on `hypex` does not restrict anything new either: there is no `hypex` release that works on 3.14, so on that version pip now skips the extra cleanly instead of failing to install it.

### Verification

```
poetry lock --no-cache
```

Fails on master; resolves in ~2 minutes with this change. `pre-commit run --all-files` passes, including `set-py-versions`, which no longer rewrites `pyproject.toml` — the constant and the generated line now agree.

### Why CI did not catch it

`tox.ini` installs with `pip install -e .[all]`, and pip only checks `requires-python` against the running interpreter instead of solving across a range. The docs workflows call the script with `-c`, which pins a single version (`~3.11.0`) and resolves trivially. The one line in `tox.ini` that would have exercised `-f` is commented out, so the "all versions" path is never run in CI.

### Note

`poetry check` reports separate, pre-existing errors on master about `scikit-image` and `efficientnet-pytorch` being listed in `[tool.poetry.extras]` without being declared as optional dependencies. Unrelated to this change; I will open a separate issue.
